### PR TITLE
refactor buildRoutes: require express instead of passing as arg

### DIFF
--- a/app/server/index.js
+++ b/app/server/index.js
@@ -15,7 +15,7 @@ require('./middleware/cors')(server);
 require('./middleware/expressDevice')(server);
 
 // build Routes
-require('./utils/buildRoutes')(appConfig, server, express);
+require('./utils/buildRoutes')(appConfig, server);
 
 // Handle unspecified routes
 server.use((req, res) =>
@@ -25,7 +25,7 @@ server.use((req, res) =>
 );
 
 // connect server
-const { Name, Host, Port } = appConfig.Config;
+const { Host, Port } = appConfig.Config;
 
 server.listen(Port, error => {
   if (error) return logger.error(`Error starting server`, error);

--- a/app/server/utils/buildRoutes.js
+++ b/app/server/utils/buildRoutes.js
@@ -1,4 +1,6 @@
-module.exports = (appConfig, server, express) =>
+const express = require('express')
+
+module.exports = (appConfig, server) =>
   Object.keys(appConfig.Components).forEach(key => {
     if (appConfig.Components[key].Routes) {
       const routesPath = `../../${key.toLowerCase()}/routes`


### PR DESCRIPTION
also minor: remove unused/unpassed variable `Name` pulled off config object in `buildRoutes.js`

closed: moving over to enmapi